### PR TITLE
FIX: Replaced all instances of context_type with content_type (typo)

### DIFF
--- a/modules/height.js
+++ b/modules/height.js
@@ -13,12 +13,12 @@ export default function(controller, nlp) {
         bot.reply(message, {
           text: "Thank you, I've updated your profile",
           quick_replies: [{
-            context_type: 'text',
+            content_type: 'text',
             title: 'What is my BMI?',
             payload: 'what is my bmi',
           },
           {
-            context_type: 'text',
+            content_type: 'text',
             title: 'How do you calculate my BMI?',
             payload: 'how do you calculate my bmi',
           }]

--- a/modules/profile.js
+++ b/modules/profile.js
@@ -25,12 +25,12 @@ export default function(controller, apiai = {}) {
                           convo.ask({
                             text: 'You want me to call you `' + response.text + '`?',
                             quick_replies: [{
-                              context_type: 'text',
+                              content_type: 'text',
                               title: 'Yes',
                               payload: 'yes',
                             },
                             {
-                              context_type: 'text',
+                              content_type: 'text',
                               title: 'No',
                               payload: 'no',
                             }]

--- a/modules/system.js
+++ b/modules/system.js
@@ -5,7 +5,7 @@ export default function(controller) {
             convo.addQuestion({
                 text: "I think you know what the problem is just as well as I do",
                 quick_replies: [{
-                  context_type: 'text',
+                  content_type: 'text',
                   title: "What are you talking about?",
                   payload: 'talking',
                 },
@@ -18,7 +18,7 @@ export default function(controller) {
             convo.ask({
                 text: "I\'m sorry Dave, I\'m affraid I can\'t do that",
                 quick_replies: [{
-                  context_type: 'text',
+                  content_type: 'text',
                   title: "What's the problem?",
                   payload: 'problem',
                 },

--- a/modules/weight.js
+++ b/modules/weight.js
@@ -13,12 +13,12 @@ export default function(controller, nlp) {
                 bot.reply(message, {
                   text: "Thank you. Knowing your own weight will help you reach your goals",
                   quick_replies: [{
-                    context_type: 'text',
+                    content_type: 'text',
                     title: 'What is my BMI?',
                     payload: 'what is my bmi',
                   },
                   {
-                    context_type: 'text',
+                    content_type: 'text',
                     title: 'How do you calculate my BMI?',
                     payload: 'how do you calculate my bmi',
                   }]
@@ -36,17 +36,17 @@ export function askWeight(bot, message, say = '', cb) {
       convo.ask({
         text: 'What is your current weight in kilograms?',
         quick_replies: [{
-          context_type: 'text',
+          content_type: 'text',
           title: '70kg',
           payload: '70kg',
         },
         {
-          context_type: 'text',
+          content_type: 'text',
           title: '80kg',
           payload: '80kg',
         },
         {
-          context_type: 'text',
+          content_type: 'text',
           title: '90kg',
           payload: '90kg',
         }]

--- a/modules/welcome.js
+++ b/modules/welcome.js
@@ -25,12 +25,12 @@ export default function(controller, nlp) {
         convo.ask({
           text: 'That looks like a banana to me, is that correct?',
           quick_replies: [{
-            context_type: 'text',
+            content_type: 'text',
             title: 'Yes',
             payload: 'yes',
           },
           {
-            context_type: 'text',
+            content_type: 'text',
             title: 'No',
             payload: 'no',
           }]
@@ -76,12 +76,12 @@ export default function(controller, nlp) {
         convo.ask({
           text: 'That looks like a chocolate bar to me, is that correct?',
           quick_replies: [{
-            context_type: 'text',
+            content_type: 'text',
             title: 'Yes',
             payload: 'yes',
           },
           {
-            context_type: 'text',
+            content_type: 'text',
             title: 'No',
             payload: 'no',
           }]
@@ -126,22 +126,22 @@ export default function(controller, nlp) {
       convo.ask({
         text: "And how long do you think you'd need to walk to work off those calories?",
         quick_replies: [{
-          context_type: 'text',
+          content_type: 'text',
           title: '10 min',
           payload: '10 min',
         },
         {
-          context_type: 'text',
+          content_type: 'text',
           title: '30 min',
           payload: '30 min',
         },
         {
-          context_type: 'text',
+          content_type: 'text',
           title: '1 hour',
           payload: '1 hour',
         },
         {
-          context_type: 'text',
+          content_type: 'text',
           title: '2 hours',
           payload: '2 hours',
         },]
@@ -162,22 +162,22 @@ export default function(controller, nlp) {
       convo.ask({
           text: "What kind of food do you usually have for dinner?",
           quick_replies: [{
-            context_type: 'text',
+            content_type: 'text',
             title: 'Japanese',
             payload: 'Japanese',
           },
           {
-            context_type: 'text',
+            content_type: 'text',
             title: 'Indian',
             payload: 'Indian',
           },
           {
-            context_type: 'text',
+            content_type: 'text',
             title: 'Vegetarian',
             payload: 'vegetarian',
           },
           {
-            context_type: 'text',
+            content_type: 'text',
             title: 'Meat and veg',
             payload: 'meat and veg',
           },
@@ -198,12 +198,12 @@ export default function(controller, nlp) {
       convo.ask({
           text: "If you'd like some recipes or meal plan, just ask",
           quick_replies: [{
-            context_type: 'text',
+            content_type: 'text',
             title: 'Recipes',
             payload: 'recipes',
           },
           {
-            context_type: 'text',
+            content_type: 'text',
             title: 'Meal plan',
             payload: 'meal plan',
           },


### PR DESCRIPTION
I can't see any difference in behaviour -- perhaps text is the default content_type anyway. It may save us from frustration later if we use another content_type though.